### PR TITLE
fix: sort author manually from mdx

### DIFF
--- a/src/components/Blog/Authors.tsx
+++ b/src/components/Blog/Authors.tsx
@@ -92,9 +92,9 @@ const BlogAuthors = (props: Props) => {
 
   if (!authors) return null;
 
-  const filteredAuthors = authorList.filter((author) =>
-    authors.includes(author.name)
-  );
+  const filteredAuthors = authorList
+    .filter((author) => authors.includes(author.name))
+    .sort((a, b) => authors.indexOf(a.name) - authors.indexOf(b.name));
 
   return (
     <div className="flex flex-row items-center mt-4 mb-8 w-full">


### PR DESCRIPTION
![Screenshot 2024-08-07 at 12 34 22](https://github.com/user-attachments/assets/75ef740b-4c80-4a53-b95e-1994d4c296a9)

![Screenshot 2024-08-07 at 12 34 26](https://github.com/user-attachments/assets/fa8f8512-3b49-41bf-96b6-b84db6445626)

Sort order manually from mdx,

example : 

`<BlogAuthors authors={["Alan Dao", "Rex Ha", "Bach Vu", "Phong Tran"]}/>`

will render `"Alan Dao", "Rex Ha", "Bach Vu", "Phong Tran"`

`<BlogAuthors authors={["Rex Ha", "Alan Dao", "Bach Vu", "Phong Tran"]}/>`

will render `"Rex Ha", "Alan Dao", "Bach Vu", "Phong Tran"`



